### PR TITLE
Add FastAPI service for party updates

### DIFF
--- a/src/add_party_to_emendas.py
+++ b/src/add_party_to_emendas.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .party_service import add_parties_to_csv
+
+
+def main(csv_path: str) -> None:
+    add_parties_to_csv(csv_path)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Add SG_PARTIDO column to emendas CSV")
+    parser.add_argument("csv_path", help="Path to emendas_por_favorecido.csv")
+
+    args = parser.parse_args()
+    main(args.csv_path)

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .party_service import add_parties_to_csv
+
+app = FastAPI(title="Emendas Party Service")
+
+
+class AddPartiesRequest(BaseModel):
+    csv_path: str
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/add-parties")
+def add_parties(request: AddPartiesRequest) -> dict[str, int]:
+    try:
+        rows = add_parties_to_csv(request.csv_path)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"rows": rows}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("src.app:app", host="0.0.0.0", port=8000)

--- a/src/party_service.py
+++ b/src/party_service.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from time import sleep
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from unidecode import unidecode
+
+API_URL = "https://dadosabertos.camara.leg.br/api/v2/deputados?nome={name}"
+
+
+def _query_api(query_name: str) -> str | None:
+    """Query Camara API for a deputy and return party acronym if found."""
+    url = API_URL.format(name=quote(query_name))
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urlopen(req) as resp:
+        data = json.load(resp)
+    deputados = data.get("dados", [])
+    if deputados:
+        return deputados[0].get("siglaPartido")
+    return None
+
+
+def fetch_party(name: str) -> str:
+    """Return party acronym for a deputy name using Camara API."""
+    # First attempt with provided name
+    party = _query_api(name)
+    if party:
+        return party
+
+    # Fallback: remove common titles
+    clean = unidecode(name)
+    tokens = [
+        t
+        for t in clean.replace(".", " ").split()
+        if t.upper() not in {"PROF", "PROFESSOR", "DEPUTADO", "PASTOR", "SENADOR"}
+    ]
+    if tokens:
+        party = _query_api(" ".join(tokens))
+        if party:
+            return party
+    return "UNKNOWN"
+
+
+def add_parties_to_csv(csv_path: str) -> int:
+    """Add SG_PARTIDO column to CSV file. Return number of rows processed."""
+    path = Path(csv_path)
+    rows: list[dict[str, str]] = []
+    with path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+    unique_names = sorted({row["Nome do Autor da Emenda"] for row in rows})
+    name_to_party: dict[str, str] = {}
+    for name in unique_names:
+        party = fetch_party(name)
+        name_to_party[name] = party
+        sleep(0.2)  # be gentle with the API
+
+    for row in rows:
+        row["SG_PARTIDO"] = name_to_party.get(row["Nome do Autor da Emenda"], "UNKNOWN")
+
+    fieldnames = list(rows[0].keys())
+    with path.open("w", encoding="utf-8-sig", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return len(rows)


### PR DESCRIPTION
## Summary
- add `party_service.py` with reusable party lookup and CSV update logic
- create `app.py` exposing a FastAPI API
- refactor CLI script to use the new service

## Testing
- `python3 -m py_compile src/add_party_to_emendas.py src/party_service.py src/app.py src/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68463aa959ac833299fd9a70c7b1941d