### PR TITLE
Add party insertion script and data merge notebook

### DIFF
--- a/notebooks/09_unificar_dados.ipynb
+++ b/notebooks/09_unificar_dados.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be7680a0",
+   "metadata": {},
+   "source": [
+    "## Unificação das bases de dados"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "752ca407",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import re\n",
+    "from unidecode import unidecode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e24b25b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def normalize_municipio(nome: str) -> str:\n",
+    "    \"\"\"Remove acentos e padroniza como 'MUNICIPIO - UF'\"\"\"\n",
+    "    if pd.isna(nome):\n",
+    "        return None\n",
+    "    nome = unidecode(str(nome)).upper().strip()\n",
+    "    m = re.search(r\"\\((\\w{2})\\)$\", nome)\n",
+    "    uf = None\n",
+    "    if m:\n",
+    "        uf = m.group(1)\n",
+    "        base = nome[:m.start()].strip()\n",
+    "    else:\n",
+    "        m = re.search(r\"\\s-\\s([A-Z]{2})$\", nome)\n",
+    "        if m:\n",
+    "            uf = m.group(1)\n",
+    "            base = nome[:m.start()].strip()\n",
+    "        else:\n",
+    "            base = nome\n",
+    "    return f\"{base} - {uf}\" if uf else base\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1308c06a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Carregar emendas com partidos e agregar por município\n",
+    "emendas = pd.read_csv('../data/emendas_por_favorecido_partidos.csv', encoding='utf-8-sig')\n",
+    "emendas['municipio'] = (emendas['Município Favorecido'] + ' - ' + emendas['UF Favorecido']).apply(normalize_municipio)\n",
+    "agg = (emendas.groupby('municipio', as_index=False)['Valor Recebido']\n",
+    "               .sum()\n",
+    "               .rename(columns={'Valor Recebido': 'valor_pix_total'}))\n",
+    "\n",
+    "# Indicadores IBGE\n",
+    " dens = pd.read_csv('../data/densidade.csv')\n",
+    " dens['municipio'] = dens['name_muni_x'].apply(normalize_municipio)\n",
+    " dens = dens[['code_muni', 'municipio', 'densidade_demografica']]\n",
+    "\n",
+    " escolar = pd.read_csv('../data/escolarizacao.csv')\n",
+    " escolar['municipio'] = escolar['Territorialidades'].apply(normalize_municipio)\n",
+    " escolar = escolar[['municipio', 'Taxa de Educacao 2010']]\n",
+    "\n",
+    " idhm = pd.read_csv('../data/idhm.csv')\n",
+    " idhm['municipio'] = idhm['Territorialidades'].apply(normalize_municipio)\n",
+    " idhm = idhm[['municipio', 'IDHM 2010']]\n",
+    "\n",
+    " pib = pd.read_csv('../data/pib_per_capita.csv')\n",
+    " pib['municipio'] = pib['name_muni'].apply(normalize_municipio)\n",
+    " pib = pib[['municipio', 'pib_per_capita_2021']]\n",
+    "\n",
+    " resultados = pd.read_csv('../data/resultados_eleicoes.csv')\n",
+    " resultados['municipio'] = (resultados['NM_MUNICIPIO'] + ' - ' + resultados['SG_UF']).apply(normalize_municipio)\n",
+    " prefeitos = resultados[resultados['DS_SIT_TOT_TURNO'] == 'ELEITO']\n",
+    " prefeitos = prefeitos.drop_duplicates('municipio')[['municipio', 'NM_URNA_CANDIDATO']]                    .rename(columns={'NM_URNA_CANDIDATO': 'prefeito_eleito'})\n",
+    "\n",
+    "# Merge de todas as bases\n",
+    "base = agg.merge(dens, on='municipio', how='left')\n",
+    "base = base.merge(pib, on='municipio', how='left')\n",
+    "base = base.merge(idhm, on='municipio', how='left')\n",
+    "base = base.merge(escolar, on='municipio', how='left')\n",
+    "base = base.merge(prefeitos, on='municipio', how='left')\n",
+    "\n",
+    "# Seleciona colunas principais\n",
+    "dados_unificados = base[['municipio', 'code_muni', 'valor_pix_total',\n",
+    "                         'pib_per_capita_2021', 'densidade_demografica',\n",
+    "                         'IDHM 2010', 'Taxa de Educacao 2010', 'prefeito_eleito']]\n",
+    "\n",
+    "dados_unificados.to_csv('../data/dados_unificados.csv', index=False, encoding='utf-8-sig')\n",
+    "dados_unificados.head()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/insert_parties.py
+++ b/src/insert_parties.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+def add_parties(emendas_path: str | Path,
+                mapping_path: str | Path,
+                out_path: str | Path) -> int:
+    """Add party acronym to emendas CSV.
+
+    Parameters
+    ----------
+    emendas_path : str | Path
+        Input CSV path (emendas_por_favorecido.csv).
+    mapping_path : str | Path
+        JSON file with mapping from author name to party.
+    out_path : str | Path
+        Output CSV path.
+    Returns
+    -------
+    int
+        Number of rows written to ``out_path``.
+    """
+    emendas_df = pd.read_csv(emendas_path, encoding="utf-8-sig")
+    with Path(mapping_path).open("r", encoding="utf-8") as f:
+        mapping: dict[str, str] = json.load(f)
+
+    emendas_df["siglaPartido"] = emendas_df["Nome do Autor da Emenda"].map(mapping).fillna("UNKNOWN")
+    emendas_df.to_csv(out_path, index=False, encoding="utf-8-sig")
+    return len(emendas_df)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Insere coluna de partido no CSV de emendas")
+    parser.add_argument(
+        "--emendas",
+        default="data/emendas_por_favorecido.csv",
+        help="CSV de entrada",
+    )
+    parser.add_argument(
+        "--mapping",
+        default="json_data/autor_partido_2024.json",
+        help="JSON com mapeamento de nomes para partidos",
+    )
+    parser.add_argument(
+        "--out",
+        default="data/emendas_por_favorecido_partidos.csv",
+        help="CSV de saída com partidos",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    rows = add_parties(args.emendas, args.mapping, args.out)
+    logger.info("Arquivo gerado: %s (%d linhas)", args.out, rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `insert_parties.py` script to fill party acronyms in `emendas_por_favorecido.csv`
- provide new notebook `09_unificar_dados.ipynb` to merge all data sources into one CSV

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6848d0057bf08332ab988271378a0f39