### PR TITLE
Add party script defaults and usage readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Emendas PIX
+
+Scripts e notebooks para integrar dados de emendas parlamentares do tipo PIX e indicadores municipais.
+
+## Instruções rápidas
+
+1. Gere o arquivo `emendas_por_favorecido_partidos.csv` com a coluna de partido executando:
+
+```bash
+python src/insert_parties.py \
+  --emendas data/emendas_por_favorecido.csv \
+  --mapping json_data/politicos_partidos_padronizado.json \
+  --out data/emendas_por_favorecido_partidos.csv
+```
+
+2. Execute o notebook `notebooks/09_unificar_dados.ipynb` para unificar os dados da pasta `data` em `data/dados_unificados.csv`.
+

--- a/src/insert_parties.py
+++ b/src/insert_parties.py
@@ -48,7 +48,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--mapping",
-        default="json_data/autor_partido_2024.json",
+        default="json_data/politicos_partidos_padronizado.json",
         help="JSON com mapeamento de nomes para partidos",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- document how to generate CSVs
- update insert_parties.py to use existing party mapping JSON

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile src/insert_parties.py`
- `python - <<'PY'\nimport nbformat\nnbformat.read('notebooks/09_unificar_dados.ipynb', as_version=4)\nprint('Notebook OK')\nPY`
- `python src/insert_parties.py --emendas data/emendas_por_favorecido.csv --mapping json_data/politicos_partidos_padronizado.json --out data/emendas_por_favorecido_partidos.csv`

------
https://chatgpt.com/codex/tasks/task_e_6848d331fdbc8332a34bf51253087709