### PR TITLE
Add coefficient analysis to multilevel notebook

### DIFF
--- a/notebooks/multilevel_modeling.ipynb
+++ b/notebooks/multilevel_modeling.ipynb
@@ -267,6 +267,55 @@
     "full_res = full_model.fit()\n",
     "print(full_res.summary())\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Análise dos coeficientes\n",
+    "A seguir resumimos os parâmetros do modelo completo para verificar quais variáveis apresentam efeitos estatisticamente significativos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "summary_df = pd.DataFrame({\n",
+    "    'coeficiente': full_res.params,\n",
+    "    'erro_padrao': full_res.bse,\n",
+    "    'p_valor': full_res.pvalues\n",
+    "})\n",
+    "summary_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coef_df = summary_df.loc[['emendas_pix_per_capita_partido_prefeito_eleito', 'cluster_1', 'cluster_2', 'cluster_3']]\n",
+    "coef_df = coef_df.reset_index().rename(columns={'index': 'variavel'})\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "sns.pointplot(data=coef_df, x='coeficiente', y='variavel', join=False, xerr=1.96*coef_df['erro_padrao'])\n",
+    "plt.axvline(0, color='red', linestyle='--', linewidth=1)\n",
+    "plt.title('Coeficientes do modelo completo (95% IC)')\n",
+    "plt.xlabel('Efeito estimado')\n",
+    "plt.ylabel('')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Os coeficientes dos clusters 2 e 3 apresentam p-valores menores que 0.05, indicando que essas variáveis possuem efeito significativo. Em contrapartida, o coeficiente associado ao volume de Emendas PIX por prefeito não difere de zero no modelo final."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- extend multilevel modeling notebook with analysis section
- add code to show coefficients and generate confidence interval plot
- note significance of coefficients in markdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6845d18083328059bc1817434f99